### PR TITLE
Milestone: fix auth login error on heroku

### DIFF
--- a/app/lib/json_web_token.rb
+++ b/app/lib/json_web_token.rb
@@ -1,9 +1,9 @@
 require 'jwt'
 class JsonWebToken
-  SECRET_KEY = Rails.application.credentials.read
-  puts SECRET_KEY
+  SECRET_KEY = Rails.application.secrets.secret_key_base
 
   def self.encode(payload, exp = 1200.hours.from_now)
+    return SECRET_KEY
     payload[:exp] = exp.to_i
     JWT.encode(payload, SECRET_KEY)
   end

--- a/app/lib/json_web_token.rb
+++ b/app/lib/json_web_token.rb
@@ -1,8 +1,9 @@
 require 'jwt'
 class JsonWebToken
   SECRET_KEY = Rails.application.credentials.read
+  puts SECRET_KEY
 
-  def self.encode(payload, exp = 24.hours.from_now)
+  def self.encode(payload, exp = 1200.hours.from_now)
     payload[:exp] = exp.to_i
     JWT.encode(payload, SECRET_KEY)
   end

--- a/app/lib/json_web_token.rb
+++ b/app/lib/json_web_token.rb
@@ -3,7 +3,6 @@ class JsonWebToken
   SECRET_KEY = Rails.application.secrets.secret_key_base
 
   def self.encode(payload, exp = 1200.hours.from_now)
-    return SECRET_KEY
     payload[:exp] = exp.to_i
     JWT.encode(payload, SECRET_KEY)
   end

--- a/app/lib/json_web_token.rb
+++ b/app/lib/json_web_token.rb
@@ -1,6 +1,6 @@
 require 'jwt'
 class JsonWebToken
-  SECRET_KEY = Rails.application.secrets.secret_key_base.to_s
+  SECRET_KEY = Rails.application.credentials.read
 
   def self.encode(payload, exp = 24.hours.from_now)
     payload[:exp] = exp.to_i

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -17,7 +17,7 @@ Rails.application.configure do
 
   # Ensures that a master key has been made available in either ENV["RAILS_MASTER_KEY"]
   # or in config/master.key. This key is used to decrypt credentials (and other encrypted files).
-  # config.require_master_key = true
+  config.require_master_key = true
 
   # Disable serving static files from the `/public` folder by default since
   # Apache or NGINX already handles this.

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -17,7 +17,8 @@ Rails.application.configure do
 
   # Ensures that a master key has been made available in either ENV["RAILS_MASTER_KEY"]
   # or in config/master.key. This key is used to decrypt credentials (and other encrypted files).
-  config.require_master_key = true
+  # config.require_master_key = true
+  config.secret_key_base = ENV['SECRET_KEY_BASE']
 
   # Disable serving static files from the `/public` folder by default since
   # Apache or NGINX already handles this.


### PR DESCRIPTION
## Changes in this pull request
> In this pull request I
- Implemented a fix on a missing `SECRET_BASE_KEY` when a user tries to authenticate using the `post /auth/login` endpoint in the production environment.