### PR TITLE
Add user role to the login endpoint response

### DIFF
--- a/app/controllers/authentication_controller.rb
+++ b/app/controllers/authentication_controller.rb
@@ -10,7 +10,7 @@ class AuthenticationController < ApplicationController
       token = JsonWebToken.encode(user_id: @user.id)
       time = Time.now + 24.hours.to_i
       render json: { id: @user.id, token:, exp: time.strftime('%m-%d-%Y %H:%M'),
-                     username: @user.name, email: @user.email }, status: :ok
+                     username: @user.name, email: @user.email, role: @user.role }, status: :ok
     else
       render json: { error: 'unauthorized' }, status: :unauthorized
     end


### PR DESCRIPTION
## Changes in this pull request
> In this pull request I
- Added a new key `role` to the JSON response returned from API when a user logs in